### PR TITLE
refactor: rename header guard macro

### DIFF
--- a/include/siphash-hpp/siphash.hpp
+++ b/include/siphash-hpp/siphash.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef __SIPHASH__HEADER__ONLY__HPP__INCLUDED__
-#define __SIPHASH__HEADER__ONLY__HPP__INCLUDED__
+#ifndef SIPHASH_HPP_INCLUDED
+#define SIPHASH_HPP_INCLUDED
 
 #include <string>
 #include <cstdint>
@@ -204,4 +204,4 @@ namespace siphash_hpp {
     }
 };
 
-#endif // __SIPHASH__HEADER__ONLY__HPP__INCLUDED__
+#endif // SIPHASH_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- rename header guard macro to `SIPHASH_HPP_INCLUDED`

## Testing
- `g++ -std=c++11 code-blocks/examples/main.cpp -Iinclude/siphash-hpp -o siphash_example`
- `./siphash_example`


------
https://chatgpt.com/codex/tasks/task_e_68b8f7a80958832cb5f50bd203497e0c