### PR TITLE
Add CMake test setup and CI workflows

### DIFF
--- a/.github/workflows/CI-Linux.yml
+++ b/.github/workflows/CI-Linux.yml
@@ -1,0 +1,26 @@
+name: CI-Linux
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+      - stable
+  pull_request:
+    branches:
+      - main
+      - release/**
+      - codex/**
+
+jobs:
+  Tests-Linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Run Tests
+        run: |
+          sudo apt-get update && sudo apt-get install -y cmake
+          CXX_STANDARD=${{ matrix.std }} ./scripts/run_tests.sh

--- a/.github/workflows/CI-Win.yml
+++ b/.github/workflows/CI-Win.yml
@@ -1,0 +1,35 @@
+name: CI-Win
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+      - stable
+  pull_request:
+    branches:
+      - main
+      - release/**
+      - codex/**
+
+jobs:
+  Tests-Win:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: MINGW64
+          install: >-
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-make
+      - name: Build and Run Tests
+        shell: msys2 {0}
+        run: |
+          export CXX_STANDARD=${{ matrix.std }}
+          ./scripts/run_tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,4 +13,4 @@
 
 ## Tooling
 
-- Run tests before committing changes.
+- Run `./scripts/run_tests.sh` before committing changes and ensure it passes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.16)
+project(siphash-hpp VERSION 1.0 LANGUAGES CXX)
+
+option(BUILD_TESTING "Build tests" ON)
+
+add_library(siphash_hpp INTERFACE)
+target_include_directories(siphash_hpp INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/siphash-hpp>
+    $<INSTALL_INTERFACE:include/siphash-hpp>)
+
+include(CMakePackageConfigHelpers)
+
+install(TARGETS siphash_hpp EXPORT siphash-hpp-targets)
+install(DIRECTORY include/siphash-hpp/ DESTINATION include/siphash-hpp)
+
+install(EXPORT siphash-hpp-targets
+  FILE siphash-hpp-targets.cmake
+  NAMESPACE siphash_hpp::
+  DESTINATION lib/cmake/siphash-hpp)
+
+configure_package_config_file(
+  cmake/siphash-hpp-config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config.cmake
+  INSTALL_DESTINATION lib/cmake/siphash-hpp)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/siphash-hpp-config-version.cmake
+  DESTINATION lib/cmake/siphash-hpp)
+
+if(BUILD_TESTING)
+  enable_testing()
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip)
+  FetchContent_MakeAvailable(googletest)
+
+  add_executable(siphash_tests tests/siphash_tests.cpp)
+  target_link_libraries(siphash_tests PRIVATE siphash_hpp gtest_main)
+  add_test(NAME siphash_tests COMMAND siphash_tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # siphash-hpp
 
+[![CI-Linux](https://github.com/OWNER/siphash-hpp/actions/workflows/CI-Linux.yml/badge.svg)](https://github.com/OWNER/siphash-hpp/actions/workflows/CI-Linux.yml)
+[![CI-Win](https://github.com/OWNER/siphash-hpp/actions/workflows/CI-Win.yml/badge.svg)](https://github.com/OWNER/siphash-hpp/actions/workflows/CI-Win.yml)
+
 [SipHash](https://en.wikipedia.org/wiki/SipHash) header only C ++ library
 
 Exapmle:

--- a/cmake/siphash-hpp-config.cmake.in
+++ b/cmake/siphash-hpp-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/siphash-hpp-targets.cmake")

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build"
+
+rm -rf "$BUILD_DIR"
+cmake -S "$ROOT_DIR" -B "$BUILD_DIR" -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=${CXX_STANDARD:-17}
+cmake --build "$BUILD_DIR" --config Release
+cd "$BUILD_DIR"
+ctest --output-on-failure

--- a/tests/siphash_tests.cpp
+++ b/tests/siphash_tests.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include "siphash.hpp"
+#include <array>
+#include <string>
+
+TEST(SipHash, KnownValues) {
+    std::array<char, 16> key = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
+    std::string data = "hello";
+
+    EXPECT_EQ(4402678656023170274ULL, siphash_hpp::siphash_2_4(data, key));
+    EXPECT_EQ(14986662229302055855ULL, siphash_hpp::siphash_4_8(data, key));
+}


### PR DESCRIPTION
## Summary
- add CMake build with gtest tests
- add run_tests script
- add Linux and Windows GitHub Actions
- show CI status badges in README

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8f79b4308832cb7b1d76a6011d1fe