### PR TITLE
refactor: return reference from update methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ std::cout << "SipHash-4-8 for 'hello': " << siphash_hpp::siphash(data, key, 4, 8
 
 siphash_hpp::SipHash siphash;
 siphash.init(key, 2, 4);
-siphash.update(data);
-std::cout << "SipHash-2-4 for 'hello': " << siphash.digest() << std::endl;
+std::cout << "SipHash-2-4 for 'hello': " << siphash.update(data).digest() << std::endl;
 ```
 
 

--- a/examples/basic.cpp
+++ b/examples/basic.cpp
@@ -17,8 +17,7 @@ int main() {
     // Using the SipHash class for custom parameters.
     siphash_hpp::SipHash hasher;
     hasher.init(key, 4, 8); // c = 4, d = 8
-    hasher.update(msg);
-    const uint64_t hash_4_8 = hasher.digest();
+    const uint64_t hash_4_8 = hasher.update(msg).digest();
     std::cout << "SipHash-4-8(\"" << msg << "\") = " << hash_4_8 << std::endl;
 
     return 0;

--- a/include/siphash-hpp/siphash.hpp
+++ b/include/siphash-hpp/siphash.hpp
@@ -100,7 +100,7 @@ namespace siphash_hpp {
             m = 0;
         }
 
-        SipHash* update(const char byte) noexcept {
+        SipHash& update(const char byte) noexcept {
             ++input_len;
             m |= (((uint64_t) byte & 0xff) << (index++ * 8));
             if (index >= 8) {
@@ -108,10 +108,10 @@ namespace siphash_hpp {
                 index = 0;
                 m = 0;
             }
-            return this;
+            return *this;
         };
 
-        inline SipHash* update(const char* data, const size_t length) noexcept {
+        inline SipHash& update(const char* data, const size_t length) noexcept {
             size_t i = 0;
 
             // If there is data left in the internal buffer, fill it first
@@ -144,10 +144,10 @@ namespace siphash_hpp {
                       << (index++ * 8));
             }
 
-            return this;
+            return *this;
         }
 
-        inline SipHash* update(const std::string &data) noexcept {
+        inline SipHash& update(const std::string &data) noexcept {
             return update(data.data(), data.size());
         }
 


### PR DESCRIPTION
## Summary
- return `SipHash&` from all `update` overloads
- chain `update` calls with `.` in examples and docs

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8fc13dbec832c9e701d1fd868c5c5