### PR TITLE
Enforce minimum key size for SipHash initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![Linux](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Linux.yml/badge.svg)](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Linux.yml)
 [![Win](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Win.yml/badge.svg)](https://github.com/NewYaroslav/siphash-hpp/actions/workflows/CI-Win.yml)
 
-[SipHash](https://en.wikipedia.org/wiki/SipHash) header only C ++ library
+[SipHash](https://en.wikipedia.org/wiki/SipHash) header only C ++ library.
 
-Exapmle:
+The key must contain at least 16 bytes.
+
+Example:
 
 ```cpp
 #include "siphash.hpp"


### PR DESCRIPTION
## Summary
- enforce minimum key length via static_assert/assert in init
- document key size requirement in README
- fix typo in README example

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8fc0c6624832c8127b89e09e59437