### PR TITLE
refactor: simplify padding loop

### DIFF
--- a/include/siphash-hpp/siphash.hpp
+++ b/include/siphash-hpp/siphash.hpp
@@ -211,9 +211,7 @@ namespace siphash_hpp {
         }
 
         const uint64_t digest() noexcept {
-            while (index < 7) {
-                m |= 0 << (index++ * 8);
-            }
+            while (index < 7) ++index;
             m |= ((uint64_t) input_len) << (index * 8);
             digest_block();
             v2 ^= 0xff;


### PR DESCRIPTION
## Summary
- remove redundant zero-padding loop in SipHash digest in favor of simple index increment

## Testing
- `./scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9027ef6a8832cbba731041f140762