### PR TITLE
build(cmake): require c++11 for interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(siphash_hpp INTERFACE)
 target_include_directories(siphash_hpp INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/siphash-hpp>
     $<INSTALL_INTERFACE:include/siphash-hpp>)
+target_compile_features(siphash_hpp INTERFACE cxx_std_11)
 
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
## Summary
- require consuming targets to build siphash_hpp with at least C++11

## Testing
- `CXX_STANDARD=11 VERBOSE=1 ./scripts/run_tests.sh`
- `cmake -S . -B build_example -DBUILD_EXAMPLES=ON -DCMAKE_CXX_STANDARD=11 -DCMAKE_VERBOSE_MAKEFILE=ON && cmake --build build_example --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b90fef2444832c984fa0c00c528dde